### PR TITLE
Added explicit value for `android:exported`

### DIFF
--- a/packages/firebase_messaging/android/src/main/AndroidManifest.xml
+++ b/packages/firebase_messaging/android/src/main/AndroidManifest.xml
@@ -2,7 +2,8 @@
   package="io.flutter.plugins.firebasemessaging">
 
   <application>
-    <service android:name=".FlutterFirebaseMessagingService">
+    <service android:name=".FlutterFirebaseMessagingService"
+      android:exported="false">
       <intent-filter>
         <action android:name="com.google.firebase.MESSAGING_EVENT"/>
       </intent-filter>


### PR DESCRIPTION
## Description

Added explicit value for `android:exported`.

## Related Issues

Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` when the corresponding component has an intent filter defined. See https://developer.android.com/guide/topics/manifest/activity-element#exported for details.
